### PR TITLE
Switch from MiqUUID to UUIDTools

### DIFF
--- a/lib/virtfs/ext4/superblock.rb
+++ b/lib/virtfs/ext4/superblock.rb
@@ -7,6 +7,7 @@ require 'binary_struct'
 require 'util/miq-uuid'
 require 'stringio'
 require 'memory_buffer'
+require 'uuidtools'
 
 require 'rufus/lru'
 
@@ -183,9 +184,9 @@ module Ext4
       @sb['last_mnt_path'].delete!("\000")
       @numGroups, @lastGroupBlocks = @sb['num_blocks'].divmod(@sb['blocks_in_group'])
       @numGroups += 1 if @lastGroupBlocks > 0
-      @fsId = MiqUUID.parse_raw(@sb['fs_id'])
+      @fsId = UUIDTools::UUID.parse_raw(@sb['fs_id'])
       @volName = @sb['vol_name']
-      @jrnlId = MiqUUID.parse_raw(@sb['jrnl_id'])
+      @jrnlId = UUIDTools::UUID.parse_raw(@sb['jrnl_id'])
     end
 
     # ////////////////////////////////////////////////////////////////////////////
@@ -228,7 +229,7 @@ module Ext4
     end
 
     def groupDescriptorSize
-      @groupDescriptorSize ||= is_enabled_64_bit? ? @sb['group_desc_size'] : GDE_SIZE 
+      @groupDescriptorSize ||= is_enabled_64_bit? ? @sb['group_desc_size'] : GDE_SIZE
     end
 
     def freeBytes

--- a/lib/virtfs/ext4/superblock.rb
+++ b/lib/virtfs/ext4/superblock.rb
@@ -4,7 +4,6 @@ require 'fs/ext4/group_descriptor_table'
 require 'fs/ext4/inode'
 
 require 'binary_struct'
-require 'util/miq-uuid'
 require 'stringio'
 require 'memory_buffer'
 require 'uuidtools'

--- a/virtfs-ext4.gemspec
+++ b/virtfs-ext4.gemspec
@@ -18,7 +18,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.12"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_dependency "uuidtools", "~> 2.2"
+
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
This updates the code to use uuidtools instead of miq-uuid, which is being removed from gems-pending. As it stands the MiqUUID.parse_raw call would not work anyway.

I also updated the gemspec to add the uuidtools dependency, and loosen the version requirements for bundler and rake (we should not care).